### PR TITLE
Trim leading spaces from the output of `ls -laHi`

### DIFF
--- a/fzf-fs.sh
+++ b/fzf-fs.sh
@@ -28,7 +28,7 @@ __fzffs_fzf ()
         FZF_DEFAULT_COMMAND= \
         FZF_DEFAULT_OPTS= ;
 
-    fzf -x -i --prompt="${prompt} "
+    fzf -x -i --with-nth=2.. --prompt="${prompt} "
 }
 
 __fzffs_find ()
@@ -38,7 +38,7 @@ __fzffs_find ()
 
 __fzffs_ls ()
 {
-    printf '[%s] %s\n[%s] %s\n[%s] %s\n[%s] %s\n[%s] %s\n' \
+    printf '_ [%s] %s\n_ [%s] %s\n_ [%s] %s\n_ [%s] %s\n_ [%s] %s\n' \
         "." "pwd" \
         ".." "up" \
         "/" "root" \
@@ -73,7 +73,7 @@ __fzffs_browse ()
 while [[ $pwd ]]
 do
     builtin cd -- "$pwd"
-    child_ls=$(__fzffs_ls "$pwd" | __fzffs_fzf "[${pwd}]")
+    child_ls=$(__fzffs_ls "$pwd" | __fzffs_fzf "[${pwd}]" | sed 's/^[_ ]*//')
     case $child_ls in
         \[..\]*|*..)
             pwd=${pwd%/*}


### PR DESCRIPTION
Well, while trying it on OS X, I noticed that the lines from `ls -laHi` can start with leading spaces, making `${child_ls%% *}` return an empty string.

This commit also applies `--with-nth` option to hide inodes that should be irrelevant to ordinary users.

Anyway, this is fun, and I'm starting to want to support ANSI colors in fzf. :smirk: 
