### PR TITLE
Fix #11

### DIFF
--- a/fzf-fs
+++ b/fzf-fs
@@ -47,6 +47,9 @@ __fzffs_browser ()
                 browser_pwd="$OLDPWD";
             else
                 if [[ -d "$browser_pwd" ]]; then
+                    if [[ "${browser_pwd:0:1}" != \/ ]]; then
+                        browser_pwd="${PWD}/${browser_pwd}"
+                    fi;
                     if [[ "${browser_pwd:${#browser_pwd}-1}" == \/ ]]; then
                         browser_pwd="${browser_pwd%/*}";
                     else
@@ -81,7 +84,7 @@ __fzffs_browser ()
         browser_pwd_inode="${browser_pwd_inode%% *}";
         browser_pwd_inode_parent="$(command ls -id ..)";
         browser_pwd_inode_parent="${browser_pwd_inode_parent%% *}";
-        browser_selection="$(__fzffs_browser_select "$browser_pwd")";
+        browser_selection="$(__fzffs_browser_select "${browser_pwd//$'\n'/?}")";
         while [[ "${browser_selection:0:1}" == _ || "${browser_selection:0:1}" == " " ]]; do
             browser_selection="${browser_selection#_}";
             browser_selection="${browser_selection#* }";

--- a/fzf-fs-init
+++ b/fzf-fs-init
@@ -67,8 +67,8 @@ __fzffs_init ()
         ;;
         Darwin)
             FZF_FS_OS=Darwin;
-            FZF_FS_LS_COMMAND="command ls -G";
-            FZF_FS_LS_COMMAND_COLOR="CLICOLOR_FORCE=1 command ls -G"
+            FZF_FS_LS_COMMAND="command ls -G -q";
+            FZF_FS_LS_COMMAND_COLOR="CLICOLOR_FORCE=1 command ls -G -q"
         ;;
         SunOS)
             FZF_FS_OS=SunOS;
@@ -77,8 +77,8 @@ __fzffs_init ()
         ;;
         *)
             FZF_FS_OS=Linux;
-            FZF_FS_LS_COMMAND="command ls --color=auto";
-            FZF_FS_LS_COMMAND_COLOR="command ls --color=always"
+            FZF_FS_LS_COMMAND="command ls --color=auto -q";
+            FZF_FS_LS_COMMAND_COLOR="command ls --color=always -q"
         ;;
     esac;
 


### PR DESCRIPTION
- s/\n/?/g in prompt
- add `-q` to the `ls` command for Linux and MacOSX
- fix relative path handling (e.g. fzf-fs test/)
